### PR TITLE
ci(sync-upstream): add pr-labels

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -25,4 +25,7 @@ jobs:
           sync-target-repository: https://github.com/tier4/autoware_individual_params.git
           sync-target-branch: main
           pr-title: "chore: sync upstream"
+          pr-labels: |
+            bot
+            sync-upstream
           auto-merge-method: merge


### PR DESCRIPTION
A follow-up for https://github.com/tier4/autoware_individual_params/pull/34.