### PR TITLE
ci: add backport.yaml to sync-files.yaml

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -1,6 +1,7 @@
 - repository: autowarefoundation/autoware
   files:
     - source: .github/dependabot.yaml
+    - source: .github/workflows/backport.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/semantic-pull-request.yaml


### PR DESCRIPTION
The backport action is merged at https://github.com/autowarefoundation/autoware/pull/2856.
This PR add backport.yaml to sync-files action.