### PR TITLE
feat: add camera6,7 param to aip xx1 sensor kit

### DIFF
--- a/individual_params/config/default/aip_xx1/sensor_kit_calibration.yaml
+++ b/individual_params/config/default/aip_xx1/sensor_kit_calibration.yaml
@@ -41,6 +41,20 @@ sensor_kit_base_link:
     roll: 0.0
     pitch: -0.01
     yaw: 3.125
+  camera6/camera_link:
+    x: 0.396865
+    y: -0.028041
+    z: -0.204267
+    roll: 0.000933
+    pitch: 0.007147
+    yaw: 0.025164
+  camera7/camera_link:
+    x: 0.383094
+    y: 0.020355
+    z: -0.205253
+    roll: 0.011505
+    pitch: -0.017980
+    yaw: 0.034071    
   traffic_light_right_camera/camera_link:
     x: 0.05
     y: -0.0175


### PR DESCRIPTION
## Description
I added camera 6,7 camera_link to sensor_kit_base_link `sensor_kit_calibration.yaml`.

## Review Procedure(required)
Make sure that "pilot-auto" launches without an error

## Related PR(optional)
https://github.com/tier4/aip_launcher/pull/102
https://github.com/tier4/autoware_individual_params.jpntaxi/pull/56
<!-- Link related PR -->
