### PR TITLE
fix(calibration.yaml): add missing params

### DIFF
--- a/individual_params/config/default/aip_xx1/sensor_kit_calibration.yaml
+++ b/individual_params/config/default/aip_xx1/sensor_kit_calibration.yaml
@@ -54,7 +54,7 @@ sensor_kit_base_link:
     z: -0.205253
     roll: 0.011505
     pitch: -0.017980
-    yaw: 0.034071    
+    yaw: 0.034071
   traffic_light_right_camera/camera_link:
     x: 0.05
     y: -0.0175

--- a/individual_params/config/default/aip_xx1/sensors_calibration.yaml
+++ b/individual_params/config/default/aip_xx1/sensors_calibration.yaml
@@ -27,3 +27,10 @@ base_link:
     roll: -0.02
     pitch: 0.7281317
     yaw: 3.141592
+  ars408_front_center:
+    x: 3.8
+    y: 0.0
+    z: 0.5
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0


### PR DESCRIPTION
https://github.com/tier4/autoware_individual_params.jpntaxi/pull/81

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): executed command failed. Command: xacro /home/satoshi/pilot-auto/install/tier4_vehicle_launch/share/tier4_vehicle_launch/urdf/vehicle.xacro vehicle_model:=lexus sensor_model:=aip_xx1 config_dir:=/home/satoshi/pilot-auto/install/individual_params/share/individual_params/config/default/aip_xx1                                                    
Captured stderr output: error: No such key: 'ars408_front_center'                                                                                                                                                                                                                                                                                                                                                               
when evaluating expression 'calibration['base_link']['ars408_front_center']['x']'                                                                                                                                                                                                                                                                                                                                               
when instantiating macro: radar_macro (/home/satoshi/pilot-auto/install/aip_xx1_description/share/aip_xx1_description/urdf/radar.xacro)                                                                                                                                                                                                                                                                                         
in file: /home/satoshi/pilot-auto/install/aip_xx1_description/share/aip_xx1_description/urdf/sensors.xacro                                                                                                                                                                                                                                                                                                                      
included from: /home/satoshi/pilot-auto/install/tier4_vehicle_launch/share/tier4_vehicle_launch/urdf/vehicle.xacro
```
