### PR TITLE
feat: added gyro_bias_estimator.param.yaml

### DIFF
--- a/individual_params/config/default/aip_customized/gyro_bias_estimator.param.yaml
+++ b/individual_params/config/default/aip_customized/gyro_bias_estimator.param.yaml
@@ -1,0 +1,6 @@
+/**:
+  ros__parameters:
+    gyro_bias_threshold: 0.003 # [rad/s]
+    timer_callback_interval_sec: 0.5 # [sec]
+    diagnostics_updater_interval_sec: 0.5 # [sec]
+    straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]

--- a/individual_params/config/default/aip_x1/gyro_bias_estimator.param.yaml
+++ b/individual_params/config/default/aip_x1/gyro_bias_estimator.param.yaml
@@ -1,0 +1,6 @@
+/**:
+  ros__parameters:
+    gyro_bias_threshold: 0.003 # [rad/s]
+    timer_callback_interval_sec: 0.5 # [sec]
+    diagnostics_updater_interval_sec: 0.5 # [sec]
+    straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]

--- a/individual_params/config/default/aip_x2/gyro_bias_estimator.param.yaml
+++ b/individual_params/config/default/aip_x2/gyro_bias_estimator.param.yaml
@@ -1,0 +1,6 @@
+/**:
+  ros__parameters:
+    gyro_bias_threshold: 0.003 # [rad/s]
+    timer_callback_interval_sec: 0.5 # [sec]
+    diagnostics_updater_interval_sec: 0.5 # [sec]
+    straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]

--- a/individual_params/config/default/aip_xx1/gyro_bias_estimator.param.yaml
+++ b/individual_params/config/default/aip_xx1/gyro_bias_estimator.param.yaml
@@ -1,0 +1,6 @@
+/**:
+  ros__parameters:
+    gyro_bias_threshold: 0.003 # [rad/s]
+    timer_callback_interval_sec: 0.5 # [sec]
+    diagnostics_updater_interval_sec: 0.5 # [sec]
+    straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]


### PR DESCRIPTION
Allow the system to edit the `gyro_bias_estimator.param.yaml` for each vehicle.

Added to the subdirectories that satisfies `individual_params/config/*/aip_x*/`

See [the PR of aip_launcher](https://github.com/tier4/aip_launcher/pull/220) for further explanation.